### PR TITLE
Call getEntityIdLookup() directly on WikibaseClient

### DIFF
--- a/includes/FemiwikiHooks.php
+++ b/includes/FemiwikiHooks.php
@@ -60,7 +60,7 @@ class FemiwikiHooks {
 		}
 
 		$wikibaseClient = WikibaseClient::getDefaultInstance();
-		$entityIdLookup = $wikibaseClient->getStore()->getEntityIdLookup();
+		$entityIdLookup = $wikibaseClient->getEntityIdLookup();
 		return $entityIdLookup->getEntityIdForTitle( $title );
 	}
 


### PR DESCRIPTION
The ClientStore method has been deprecated for a while.