### PR TITLE
Add ability to set default options only for new

### DIFF
--- a/.github/workflows/dependencies
+++ b/.github/workflows/dependencies
@@ -1,4 +1,5 @@
 CategoryTree
 Disambiguator
+GrowthExperiments
 PageViewInfo
 Wikibase

--- a/.phan/config.php
+++ b/.phan/config.php
@@ -7,6 +7,7 @@ $cfg['directory_list'] = array_merge(
 	[
 		'../../extensions/CategoryTree',
 		'../../extensions/Disambiguator',
+		'../../extensions/GrowthExperiments',
 		'../../extensions/PageViewInfo',
 		'../../extensions/Wikibase',
 	]
@@ -17,6 +18,7 @@ $cfg['exclude_analysis_directory_list'] = array_merge(
 	[
 		'../../extensions/CategoryTree',
 		'../../extensions/Disambiguator',
+		'../../extensions/GrowthExperiments',
 		'../../extensions/PageViewInfo',
 		'../../extensions/Wikibase',
 	]

--- a/extension.json
+++ b/extension.json
@@ -23,21 +23,27 @@
     }
   },
   "HookHandlers": {
-    "default": {
-      "class": "MediaWiki\\Extension\\UnifiedExtensionForFemiwiki\\Hooks\\Handler",
+    "main": {
+      "class": "MediaWiki\\Extension\\UnifiedExtensionForFemiwiki\\HookHandlers\\Main",
       "services": ["MainConfig"]
     },
     "RelatedArticles": {
-      "class": "MediaWiki\\Extension\\UnifiedExtensionForFemiwiki\\Hooks\\RelatedArticlesHandler",
+      "class": "MediaWiki\\Extension\\UnifiedExtensionForFemiwiki\\HookHandlers\\RelatedArticles",
       "services": ["MainConfig", "DBLoadBalancer"]
+    },
+    "DefaultOptions": {
+      "class": "MediaWiki\\Extension\\UnifiedExtensionForFemiwiki\\HookHandlers\\DefaultOptions",
+      "services": ["MainConfig", "UserOptionsManager"]
     }
   },
   "Hooks": {
-    "HtmlPageLinkRendererBegin": "default",
-    "LinkerMakeExternalLink": "default",
+    "HtmlPageLinkRendererBegin": "main",
+    "LinkerMakeExternalLink": "main",
+    "LocalUserCreated": "DefaultOptions",
     "OutputPageParserOutput": "RelatedArticles",
-    "SidebarBeforeOutput": "default",
-    "SkinAddFooterLinks": "default"
+    "SidebarBeforeOutput": "main",
+    "SkinAddFooterLinks": "main",
+    "UserResetAllOptions": "DefaultOptions"
   },
   "SpecialPages": {
     "OrderedWhatlinkshere": {
@@ -66,6 +72,10 @@
     "UnifiedExtensionForFemiwikiRelatedArticlesTargetNamespaces": {
       "value": [],
       "description": "An array of namespaces which can be a target for RelatedArticles. Empty array means allowing all namespaces."
+    },
+    "UnifiedExtensionForFemiwikiSoftDefaultOptions": {
+      "value": [],
+      "description": "This options are applied to new users and set after reset, but not applied to signed-in users"
     }
   },
   "TestAutoloadNamespaces": {

--- a/includes/HookHandlers/DefaultOptions.php
+++ b/includes/HookHandlers/DefaultOptions.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace MediaWiki\Extension\UnifiedExtensionForFemiwiki\HookHandlers;
+
+use Config;
+use GrowthExperiments\HelpPanelHooks;
+use GrowthExperiments\HomepageHooks;
+use MediaWiki\User\UserOptionsManager;
+
+class DefaultOptions implements
+	\MediaWiki\User\Hook\UserResetAllOptionsHook,
+	\MediaWiki\Auth\Hook\LocalUserCreatedHook
+	{
+
+	/** @var Config */
+	private $config;
+
+	/** @var UserOptionsManager */
+	private $userOptionsManager;
+
+	/**
+	 * @param Config $config
+	 * @param UserOptionsManager $userOptionsManager
+	 */
+	public function __construct( Config $config, UserOptionsManager $userOptionsManager ) {
+		$this->config = $config;
+		$this->userOptionsManager = $userOptionsManager;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function onUserResetAllOptions(
+		$user,
+		&$newOptions,
+		$options,
+		$resetKinds
+	) {
+		$config = $this->config;
+
+		foreach ( $config->get( 'UnifiedExtensionForFemiwikiSoftDefaultOptions' ) as $opt => $val ) {
+			$newOptions[$opt] = $val;
+		}
+
+		if ( !\ExtensionRegistry::getInstance()->isLoaded( 'GrowthExperiments' ) ) {
+			return;
+		}
+
+		if ( $config->get( 'GEHelpPanelNewAccountEnablePercentage' ) == 100 ) {
+			$newOptions[HelpPanelHooks::HELP_PANEL_PREFERENCES_TOGGLE] = 1;
+		}
+
+		if ( $config->get( 'GEHomepageNewAccountEnablePercentage' ) == 100 ) {
+			$newOptions[HomepageHooks::HOMEPAGE_PREF_ENABLE] = 1;
+			$newOptions[HomepageHooks::HOMEPAGE_PREF_PT_LINK] = 1;
+		}
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function onLocalUserCreated( $user, $autocreated ) {
+		if ( !$user->isRegistered() || $autocreated ) {
+			return;
+		}
+
+		$config = $this->config;
+		$userOptionsManager = $this->userOptionsManager;
+
+		foreach ( $config->get( 'UnifiedExtensionForFemiwikiSoftDefaultOptions' ) as $opt => $val ) {
+			$userOptionsManager->setOption( $user, $opt, $val );
+		}
+	}
+}

--- a/includes/HookHandlers/Main.php
+++ b/includes/HookHandlers/Main.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace MediaWiki\Extension\UnifiedExtensionForFemiwiki\Hooks;
+namespace MediaWiki\Extension\UnifiedExtensionForFemiwiki\HookHandlers;
 
 use Config;
 use Html;
@@ -10,7 +10,7 @@ use Title;
 use Wikibase\Client\ClientHooks;
 use Wikibase\Client\WikibaseClient;
 
-class Handler implements
+class Main implements
 	\MediaWiki\Hook\LinkerMakeExternalLinkHook,
 	\MediaWiki\Hook\SidebarBeforeOutputHook,
 	\MediaWiki\Hook\SkinAddFooterLinksHook,

--- a/includes/HookHandlers/RelatedArticles.php
+++ b/includes/HookHandlers/RelatedArticles.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace MediaWiki\Extension\UnifiedExtensionForFemiwiki\Hooks;
+namespace MediaWiki\Extension\UnifiedExtensionForFemiwiki\HookHandlers;
 
 use Config;
 use ExtensionRegistry;
@@ -10,7 +10,7 @@ use Wikimedia\Rdbms\DBConnRef;
 use Wikimedia\Rdbms\ILoadBalancer;
 use Wikimedia\Rdbms\SelectQueryBuilder;
 
-class RelatedArticlesHandler implements
+class RelatedArticles implements
 	\MediaWiki\Hook\OutputPageParserOutputHook
 	{
 


### PR DESCRIPTION
- Introduces `$wgUnifiedExtensionForFemiwikiSoftDefaultOptions`.
- Makes HelpPanel and Homepage are set when after reset if configured for new users.

Related to https://github.com/femiwiki/docker-mediawiki/issues/548