### PR TITLE
Stop using deprecated Hooks::isDisambiguationPage() method

### DIFF
--- a/includes/HookHandlers/RelatedArticles.php
+++ b/includes/HookHandlers/RelatedArticles.php
@@ -39,8 +39,12 @@ class RelatedArticles implements
 	 * @return bool
 	 */
 	private static function isDisambiguationPage( Title $title ) {
-		return \ExtensionRegistry::getInstance()->isLoaded( 'Disambiguator' ) &&
-			\MediaWiki\Extension\Disambiguator\Hooks::isDisambiguationPage( $title );
+		$services = MediaWikiServices::getInstance();
+		if ( !$services->hasService( 'DisambiguatorLookup' ) ) {
+				return false;
+		}
+		return $services->getService( 'DisambiguatorLookup' )
+			->isDisambiguationPage( $title );
 	}
 
 	/**


### PR DESCRIPTION
This method is being removed from Extension:Disambiguator in
https://gerrit.wikimedia.org/r/c/mediawiki/extensions/Disambiguator/+/995218
