### PR TITLE
Update namespace of hook

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -7,7 +7,7 @@
   "license-name": "AGPL-3.0-or-later",
   "type": "specialpage",
   "requires": {
-    "MediaWiki": ">= 1.35.0",
+    "MediaWiki": ">= 1.46.0",
     "extensions": {
       "CategoryTree": "*"
     }

--- a/includes/HookHandlers/Main.php
+++ b/includes/HookHandlers/Main.php
@@ -12,7 +12,7 @@ use Wikibase\Client\ClientHooks;
 use Wikibase\Client\WikibaseClient;
 
 class Main implements
-	\MediaWiki\Hook\LinkerMakeExternalLinkHook,
+	\MediaWiki\Linker\Hook\LinkerMakeExternalLinkHook,
 	\MediaWiki\Hook\SidebarBeforeOutputHook,
 	\MediaWiki\Hook\SkinAddFooterLinksHook,
 	\MediaWiki\Hook\UserMailerTransformContentHook,

--- a/includes/HookHandlers/RelatedArticles.php
+++ b/includes/HookHandlers/RelatedArticles.php
@@ -39,8 +39,12 @@ class RelatedArticles implements
 	 * @return bool
 	 */
 	private static function isDisambiguationPage( Title $title ) {
-		return \ExtensionRegistry::getInstance()->isLoaded( 'Disambiguator' ) &&
-			\MediaWiki\Extension\Disambiguator\Hooks::isDisambiguationPage( $title );
+		$services = MediaWikiServices::getInstance();
+		if ( !$services->hasService( 'DisambiguatorLookup' ) ) {
+				return false;
+		}
+		return $services->getService( 'DisambiguatorLookup' )
+			->isDisambiguationPage( $title );
 	}
 
 	/**


### PR DESCRIPTION
Update namespace for LinkerMakeExternalLinkHook

Bumped minimum MediaWiki dependency to >= 1.46, which is when
this renamespacing occurs.
