### PR TITLE
chore: use official release-please simple type instead of fork

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -19,7 +19,7 @@ jobs:
           application_id: ${{ vars.PAT_APPLICATION_ID }}
           application_private_key: ${{ secrets.PAT_APPLICATION_PRIVATE_KEY }}
 
-      - uses: femiwiki/release-please-action@femiwiki
+      - uses: googleapis/release-please-action@v4
         with:
           token: ${{ steps.get_workflow_token.outputs.token }}
-          release-type: mediawiki-skin
+          release-type: simple

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,0 +1,19 @@
+{
+  "packages": {
+    ".": {
+      "changelog-path": "CHANGELOG.md",
+      "bump-minor-pre-major": false,
+      "bump-patch-for-minor-pre-major": false,
+      "draft": false,
+      "prerelease": false,
+      "extra-files": [
+        {
+          "type": "json",
+          "path": "extension.json",
+          "jsonpath": "$.version"
+        }
+      ]
+    }
+  },
+  "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json"
+}


### PR DESCRIPTION
We forked release-please (`femiwiki/release-please-action@femiwiki`) only to add a custom `mediawiki-skin` release type, which only ever updates `skin.json`. This extension has no `skin.json`, so that update was a no-op and never touched `extension.json`.

Switch to the official action with `release-type: simple` plus an `extra-files` JSON updater pointing at `extension.json`, so each release bumps the real version field.

## Changes
- workflow: `femiwiki/release-please-action@femiwiki` → `googleapis/release-please-action@v4`
- `release-type`: `mediawiki-skin` → `simple`
- add `release-please-config.json` with an `extra-files` entry updating `extension.json` `$.version`

`simple` registers `version.txt` with `createIfMissing: false`; there is none here, so it is a silent no-op.