### PR TITLE
build: Bump mediawiki-phan-config to 0.20.0

### DIFF
--- a/.phan/config.php
+++ b/.phan/config.php
@@ -6,7 +6,6 @@ $cfg['directory_list'] = array_merge(
 	$cfg['directory_list'],
 	[
 		'../../extensions/CategoryTree',
-		'../../extensions/Disambiguator',
 		'../../extensions/SpamBlacklist',
 		'../../extensions/Wikibase',
 	]
@@ -16,7 +15,6 @@ $cfg['exclude_analysis_directory_list'] = array_merge(
 	$cfg['exclude_analysis_directory_list'],
 	[
 		'../../extensions/CategoryTree',
-		'../../extensions/Disambiguator',
 		'../../extensions/SpamBlacklist',
 		'../../extensions/Wikibase',
 	]

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "description": "an extension for femiwiki.",
   "require-dev": {
     "mediawiki/mediawiki-codesniffer": "47.0.0",
-    "mediawiki/mediawiki-phan-config": "0.14.0",
+    "mediawiki/mediawiki-phan-config": "0.20.0",
     "mediawiki/minus-x": "1.1.3",
     "php-parallel-lint/php-console-highlighter": "1.0.0",
     "php-parallel-lint/php-parallel-lint": "1.4.0",


### PR DESCRIPTION
Bumps `mediawiki/mediawiki-phan-config` 0.14.0 → 0.20.0 (phan 6.x), matching FemiwikiSkin.

The old phan-config crashed on the master image's PHP 8.4 (`Implicitly marking parameter $suggestion as nullable is deprecated` was turned into a fatal, surfacing as `Class "Phan\\Issue" not found`). 6.x runs cleanly now that #217 made phan execute inside the live Quibble image instead of the frozen `mediawiki-phan-php81`.

Also drops the `Disambiguator` entries from `.phan/config.php`, since it was removed from the CI dependency closure in #217.

Supersedes #215.