### PR TITLE
fix: Replace removed Wikibase ClientHooks with stable API

### DIFF
--- a/includes/HookHandlers/Main.php
+++ b/includes/HookHandlers/Main.php
@@ -8,7 +8,6 @@ use MediaWiki\Html\Html;
 use MediaWiki\Title\Title;
 use RequestContext;
 use Skin;
-use Wikibase\Client\ClientHooks;
 use Wikibase\Client\WikibaseClient;
 
 class Main implements
@@ -105,7 +104,7 @@ class Main implements
 	 */
 	private function addWikibaseNewItemLink( $skin, &$sidebar ): void {
 		if ( !ExtensionRegistry::getInstance()->isLoaded( 'WikibaseClient' ) ||
-			ClientHooks::buildWikidataItemLink( $skin ) ) {
+			$this->pageHasWikibaseItem( $skin ) ) {
 			return;
 		}
 		$title = $skin->getTitle();
@@ -124,6 +123,30 @@ class Main implements
 			'href' => $url,
 			'id' => 't-wikibase'
 		];
+	}
+
+	/**
+	 * Whether the current page is already connected to a Wikibase item.
+	 *
+	 * Replaces Wikibase\Client\ClientHooks::buildWikidataItemLink(), which was
+	 * removed from Wikibase on master. This replicates its check using only the
+	 * WikibaseClient service accessors and EntityIdLookup, which are present and
+	 * signature-identical on both REL1_43 and master.
+	 *
+	 * @param Skin $skin
+	 * @return bool
+	 */
+	private function pageHasWikibaseItem( $skin ): bool {
+		// The rendered page already carries the connected item id.
+		if ( $skin->getOutput()->getProperty( 'wikibase_item' ) !== null ) {
+			return true;
+		}
+		// Non-view actions: look it up from the store, as upstream did.
+		$title = $skin->getTitle();
+		if ( $title && $skin->getActionName() !== 'view' && $title->exists() ) {
+			return WikibaseClient::getEntityIdLookup()->getEntityIdForTitle( $title ) !== null;
+		}
+		return false;
 	}
 
 	/**


### PR DESCRIPTION
Wikibase removed `Wikibase\Client\ClientHooks` on master, so `addWikibaseNewItemLink()`'s call to `ClientHooks::buildWikidataItemLink()` fatals there with *Class not found*. That surfaced once #217 made the master jobs actually run: it failed `test (master, phpunit)` (`PerformanceBudgetTest::testTotalModulesSize`) and, after the phan-config 6.x bump, `test (master, phan)`.

## Fix
Replace the call with a private `pageHasWikibaseItem()` helper that reproduces upstream's exact check, the `wikibase_item` parser-output property, else `EntityIdLookup::getEntityIdForTitle()` on non-view actions, using only `WikibaseClient::getEntityIdLookup()`. Those accessors are present and signature-identical on **both REL1_43 and master** (on master the same logic now lives in `Wikibase\Client\Hooks\SidebarHookHandler`, an injected-service instance with no static entry point), so no `class_exists` branch is needed and the feature keeps working on both branches.

Should turn `test (master, phpunit)` and `test (master, phan)` green (selenium remains the known Wikibase-termbox flake).