### PR TITLE
ci: Drop Wikibase from the selenium stage

### DIFF
--- a/.github/workflows/extension-test.yml
+++ b/.github/workflows/extension-test.yml
@@ -51,7 +51,14 @@ jobs:
         with:
           stage: ${{ matrix.stage }}
           mediawiki-version: ${{ matrix.mediawiki-version }}
-          dependencies: CategoryTree SpamBlacklist Wikibase
+          # Wikibase is dropped from the selenium stage only. Quibble's selenium
+          # stage runs `npm run selenium-test` for every dependency that has it,
+          # and on REL1_43 Wikibase's wdio config globs in the wikibase-termbox
+          # specs, which need MinervaNeue + MobileFrontend to render their mobile
+          # UI and otherwise time out. Wikimedia's own downstream-extension jobs
+          # likewise do not run Wikibase's selenium. Wikibase stays for the other
+          # stages (phan/phpunit need it).
+          dependencies: ${{ matrix.stage == 'selenium' && 'CategoryTree SpamBlacklist' || 'CategoryTree SpamBlacklist Wikibase' }}
 
       - name: Upload coverage to Codecov
         if: matrix.stage == 'coverage'


### PR DESCRIPTION
The `selenium` required check has been failing on Wikibase's bundled `wikibase-termbox` selenium specs (`reading/editing/LicenseOverlay.spec.js`), which time out in `waitForTermboxToLoad`.

Root cause (confirmed against Wikimedia CI): Quibble's selenium stage runs `npm run selenium-test` for **every** dependency that defines it. On REL1_43, Wikibase's wdio config globs in the termbox specs, whose mobile UI needs **MinervaNeue + MobileFrontend** to render (it is client-side-rendered; the SSR service is unrelated). Without them the page never hydrates and the specs time out. None of this exercises this extension.

Wikimedia's own CI does not run Wikibase's selenium for downstream extensions (on master Wikibase gates its `selenium-test` script to a no-op; only REL1_43 lacks that gate). This mirrors that: **drop Wikibase from the selenium stage's dependency set only**. Wikibase stays for `phan`/`phpunit`, which need it.

Expected result: the selenium check goes green legitimately, so the repo no longer needs admin-merge overrides.